### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL scheme check

### DIFF
--- a/src/app/core/services/lazy-loading.service.ts
+++ b/src/app/core/services/lazy-loading.service.ts
@@ -144,7 +144,8 @@ export class LazyLoadingService {
       // Disallow dangerous protocols
       if (
         src.trim().startsWith('javascript:') ||
-        src.trim().startsWith('data:')
+        src.trim().startsWith('data:') ||
+        src.trim().startsWith('vbscript:')
       ) {
         return false;
       }


### PR DESCRIPTION
Potential fix for [https://github.com/alderichoarau/alderichoarau.github.io/security/code-scanning/2](https://github.com/alderichoarau/alderichoarau.github.io/security/code-scanning/2)

To fix the problem, extend the protocol check in the `isSafeImageSrc` function so that it also blocks the `vbscript:` scheme. Specifically, update the conditional at lines 145-148 to include a check for `src.trim().startsWith('vbscript:')`. No additional methods or deep changes are needed—the logic is self-contained. In this specific snippet, add the check for `vbscript:` using the same style as the others within the `if` block at line 145. No library imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
