### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/core/services/lazy-loading.service.ts
+++ b/src/app/core/services/lazy-loading.service.ts
@@ -6,6 +6,22 @@ import { Injectable } from '@angular/core';
 export class LazyLoadingService {
   private observer!: IntersectionObserver;
 
+  /**
+   * Ensures the image source (src) is not vulnerable to XSS.
+   * Allows only:
+   *  - https:// and http:// URLs
+   *  - data:image/* URIs
+   */
+  private isSafeImageSrc(src: string | null): boolean {
+    if (!src) return false;
+    // Accept only http(s) URLs or data:image URIs
+    // Disallow other protocols: javascript:, vbscript:, file:, blob:, data:text/html, etc.
+    return (
+      /^https?:\/\/[\w\-]+(\.[\w\-]+)+([\/#?]?.*)$/i.test(src) ||
+      /^data:image\/[a-zA-Z]+;base64,[A-Za-z0-9+/=]+$/i.test(src)
+    );
+  }
+
   constructor() {
     this.createObserver();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/alderichoarau/alderichoarau.github.io/security/code-scanning/1](https://github.com/alderichoarau/alderichoarau.github.io/security/code-scanning/1)

The best way to fix the problem is to ensure that any value read from a DOM node and subsequently set as an image `src` or CSS `backgroundImage` is strictly validated or sanitized. Given that the code already uses `this.isSafeImageSrc(src)` to filter the attribute, the fix should ensure that this method is robust. 

The safest approach is to implement `isSafeImageSrc()` to permit only URLs matching safe patterns (e.g., starting with `https://`, `http://`, or `data:image/`). All other schemes (e.g., `javascript:`, `vbscript:`, `data:text/html`, etc.) should be rejected. Implement strict regular expression checking inside `isSafeImageSrc()`.

To apply the fix, locate the definition of `isSafeImageSrc()` within `src/app/core/services/lazy-loading.service.ts`. If missing, add it; if present, replace its implementation with a secure pattern-based check.

**What is needed:**
- Update (or add) the private method `isSafeImageSrc(src: string): boolean` to return `true` **only** for image URLs matching allowed schemes.
- No extra imports required.

**Regions to change:** If you were shown an incomplete or stubbed `isSafeImageSrc()`, replace it. If it does not exist, add the method to the class. Use strict regular expression(s).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
